### PR TITLE
resolve issue#2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.swp
+node_modules
+.env

--- a/addy.c
+++ b/addy.c
@@ -97,9 +97,9 @@ int start_server(char *host, char *port) {
  * @param port port or protocol the server is running see /etc/services or services(2)
  * @return the response from the server
  */
-char* request(struct Http http) {
+int request(struct Http http, char *response) {
 	int fd = create_connection(http); 
-	if (fd == -1) return NULL;
+	if (fd == -1) return fd;
 
 	//Format Request
 	char *startline = "%s %s %s"; // method, route, version;
@@ -109,8 +109,10 @@ char* request(struct Http http) {
 	// Todo MERGE to one function so don't have to pass size twice
 	int ret = snprintf(req, sizeof(char) * LARGE, 
 			   req_format, 
-			   http.method, http.route, http.version,
-		       	   http.headers,
+			   http.method,
+			   http.route,
+			   http.version,
+		       http.headers,
 			   http.payload);
 	handle_snprintf(ret, sizeof(char) * LARGE);
 
@@ -119,17 +121,16 @@ char* request(struct Http http) {
 	ret = write_request(fd, req);
 	if (ret < 0) {
 		close(fd);
-		return NULL;
+		return -1;
 	}
 
-	char response[MEDIUM];
 	while (read_recv(fd, response, sizeof(char)*MEDIUM, 0) != NULL) {
 		printf("%s\n", response);
 	}
 
 	// Successs 
 	close(fd);
-	return response;
+	return 1;
 }
 
 /**

--- a/addy.c
+++ b/addy.c
@@ -84,7 +84,7 @@ int start_server(char *host, char *port) {
 		}
 
 		// Successfully made a socket
-		printf("Server listening on file descripor %i and host %s\n", fd, host_info);
+		printf("Server listening on file descriptor %i and host %s\n", fd, host_info);
 		break;
 	}
 

--- a/addy.h
+++ b/addy.h
@@ -41,7 +41,7 @@ struct Http {
  * server and client functions
 */
 int start_server(char *host, char *port);
-char* request(struct Http http);
+int request(struct Http http, char *response);
 int create_connection(struct Http http);
 char* recv_request(int fd, char *buffer, size_t length, int flags);
 char *read_recv(int socket, char *buffer, size_t length, int flags);

--- a/client.c
+++ b/client.c
@@ -1,17 +1,18 @@
 #include "addy.h"
 
 int main() {
-	struct Http http;
-	http.method = "GET";
-	http.route = "/";
-	http.version = "HTTP/1.1";
-	http.host = "localhost";
-	http.port = "3000";
-	http.headers = "host: localhost:3000";
-	http.payload = "";
-	
-	char *response = request(http);
-	if (response == NULL) {
+	struct Http options;
+	options.method = "GET";
+	options.route = "/";
+	options.version = "HTTP/1.1";
+	options.host = "localhost";
+	options.port = "3000";
+	options.headers = "host: localhost:3000";
+	options.payload = "";
+
+	char response[MEDIUM];
+	int success = request(options, response);
+	if (!success) {
 		print_callstack();
 		return -1;
 	}


### PR DESCRIPTION
resolve memory leak warning by allocating a string in main then passing it to request.
don't want clients to have to free memory when response was returned from request.