### PR TITLE
add response configuration to HTTP struct

### DIFF
--- a/addy.c
+++ b/addy.c
@@ -102,8 +102,6 @@ int request(struct Http http, char *response) {
 	if (fd == -1) return fd;
 
 	//Format Request
-	char *startline = "%s %s %s"; // method, route, version;
-	char *payload_format = "%s %s %s\r\n%s\r\n\r\n";
 	char *req_format = "%s %s %s\r\n%s%s\r\n\r\n";
 	char req[LARGE];
 	// Todo MERGE to one function so don't have to pass size twice
@@ -124,9 +122,12 @@ int request(struct Http http, char *response) {
 		return -1;
 	}
 
-	while (read_recv(fd, response, sizeof(char)*MEDIUM, 0) != NULL) {
-		printf("%s\n", response);
+	ret = read_recv(fd, response, sizeof(char)*MEDIUM, 0);
+	if (!ret) {
+		close(fd);
+		return -1;
 	}
+	printf("%s\n", response);
 
 	// Successs 
 	close(fd);
@@ -210,18 +211,22 @@ char* read_request(int fd, char *response) {
 	}
 }
 
-char *read_recv(int socket, char *buffer, size_t length, int flags) {
+/**
+ * Read the request from the client
+ * return <= 0 if an error occurred
+*/
+int read_recv(int socket, char *buffer, size_t length, int flags) {
 	int ret = recv(socket, buffer, length-1, flags);
 	if (ret == 0) {
 		printf("peer on socket %i closed connection\n", socket);
-		return NULL;
+		return 0;
 	}
 	if (ret == -1) {
 		perror("recv");
-		return NULL;
+		return -1;
 	}
 	buffer[ret] = '\0';
-	return buffer;
+	return ret;
 }
 
 /**

--- a/addy.h
+++ b/addy.h
@@ -34,6 +34,8 @@ struct Http {
 	char *port;
 	char *headers;
 	char *payload;
+	int status_code;
+	char *status_text;
 	//struct Http *response;
 };
 
@@ -44,7 +46,7 @@ int start_server(char *host, char *port);
 int request(struct Http http, char *response);
 int create_connection(struct Http http);
 char* recv_request(int fd, char *buffer, size_t length, int flags);
-char *read_recv(int socket, char *buffer, size_t length, int flags);
+int read_recv(int socket, char *buffer, size_t length, int flags);
 char* read_request(int fd, char *buffer);
 int write_request(int fd, char *buffer);
 


### PR DESCRIPTION
The line `char *response = "HTTP/1.1 200 ok\r\nConnection: close\r\nContent-Type: text/xml; charset=utf-8\r\nContent-Length: 12\r\n\r\nhello world\r\n\r\n";` was too long and messy.
return the int that is returned from `recv` in `read_recv` to be more precise and accurate.